### PR TITLE
Add initial project files and console application template

### DIFF
--- a/AZ400-81170.csproj
+++ b/AZ400-81170.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>AZ400_81170</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/AZ400-81170.sln
+++ b/AZ400-81170.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AZ400-81170", "AZ400-81170.csproj", "{92C90C23-E170-CF02-CCE3-DD8B7A9D696E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{92C90C23-E170-CF02-CCE3-DD8B7A9D696E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92C90C23-E170-CF02-CCE3-DD8B7A9D696E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92C90C23-E170-CF02-CCE3-DD8B7A9D696E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92C90C23-E170-CF02-CCE3-DD8B7A9D696E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BA0AE80B-6F33-41BD-A348-4F682B8353A7}
+	EndGlobalSection
+EndGlobal

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");


### PR DESCRIPTION
This pull request sets up a new .NET project with a basic structure, including the project file, solution file, and a simple "Hello, World!" program. 

Setup of .NET project:

* [`AZ400-81170.csproj`](diffhunk://#diff-83c3c4a7e8ca0d010957f486161d9e8868af39b28295b2133fd14d48f86213a5R1-R11): Created a new .NET project file with essential configurations, including target framework (`net10.0`), nullable reference types enabled, and implicit usings enabled.
* [`AZ400-81170.sln`](diffhunk://#diff-d14a394891a1b4aa62b4079811fe7e07f82eb846745196ea020cf1a49a5087fdR1-R24): Added a Visual Studio solution file to organize the project, including debug and release configurations.

Basic program implementation:

* [`Program.cs`](diffhunk://#diff-0b69b473fe937040615d69f606751f61ddbc2e3a1849360ff2456c22afe88c0bR1-R2): Added a simple "Hello, World!" program as the starting point for the project.